### PR TITLE
Fixed workspace config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["rust/*"]
-exclude = ["typescript", "rust/scripts"]
+members = ["rust/*", "rust/pub-sub/*"]
+exclude = ["rust/scripts", "rust/pub-sub"]
 
 [workspace.dependencies]
 candid = "0.10.0"

--- a/rust/counter/Cargo.toml
+++ b/rust/counter/Cargo.toml
@@ -2,14 +2,12 @@
 name = "counter"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 [lib]
 crate-type = ["cdylib"]
 
-
 [dependencies]
-candid = "0.10.0"
-ic-cdk = "0.12.0"
-ic-cdk-macros = "0.8.1"
-ic-stable-structures = "0.6.0"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-stable-structures.workspace = true

--- a/rust/pub-sub/publisher/Cargo.toml
+++ b/rust/pub-sub/publisher/Cargo.toml
@@ -1,18 +1,14 @@
-
 [package]
 name = "publisher"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 [lib]
 crate-type = ["cdylib"]
 
-
-
 [dependencies]
-candid = "0.10.0"
-ic-cdk = "0.12.0"
-ic-cdk-macros = "0.8.2"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
 serde = "1.0.126"
 serde_derive = "1.0.126"

--- a/rust/pub-sub/subscriber/Cargo.toml
+++ b/rust/pub-sub/subscriber/Cargo.toml
@@ -1,17 +1,14 @@
-
 [package]
 name = "subscriber"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 [lib]
 crate-type = ["cdylib"]
 
-
 [dependencies]
-candid = "0.10.0"
-ic-cdk = "0.12.0"
-ic-cdk-macros = "0.8.1"
-ic-stable-structures = "0.6.0"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-stable-structures.workspace = true
 serde = "1.0.126"

--- a/rust/stable_memory/Cargo.toml
+++ b/rust/stable_memory/Cargo.toml
@@ -2,15 +2,13 @@
 name = "stable_memory"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 [lib]
 crate-type = ["cdylib"]
 
-
 [dependencies]
-candid = "0.10.0"
-ic-cdk = "0.12.0"
-ic-cdk-macros = "0.8.1"
-ic-stable-structures = "0.6.0"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-stable-structures.workspace = true
 serde = "1.0.193"


### PR DESCRIPTION
PR fixing issue described in this URLO topic: https://users.rust-lang.org/t/managing-multiple-sub-projects-in-a-project-without-errors/103299. I also changed the `Cargo.toml` files of the workspace members to make them a little more idiomatic by removing the useless `resolver = 2` in the workspace members  (gets ignored by Cargo since the resolver is set globally for the workspace) and changed the dependencies such that the versions defined in the workspace are used.